### PR TITLE
Adding feature to define header row and start of data body.

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -55,6 +55,9 @@ CV.prototype.cvjson = function(csv, config, callback) {
   var record = []
   var header = []
 
+  var headerRow = config.headerRow || 0;
+  var bodyStart = config.bodyRow || config.headerRow + 1;
+
   cvcsv()
     .from.string(csv)
     .transform( function(row){
@@ -63,9 +66,9 @@ CV.prototype.cvjson = function(csv, config, callback) {
     })
     .on('record', function(row, index){
 
-      if (index === (config.headerRow || 0)) {
+      if (index === config.headerRow) {
         header = row;
-      } else if (index >= (config.bodyStart || (config.headerRow ? config.headerRow + 1 : 1))) {
+      } else if (index >= bodyStart) {
         var obj = {};
         header.forEach(function(column, index) {
           var key = config.lowerCaseHeaders ? column.trim().toLowerCase() : column.trim();

--- a/libs/index.js
+++ b/libs/index.js
@@ -65,7 +65,6 @@ CV.prototype.cvjson = function(csv, config, callback) {
       return row;
     })
     .on('record', function(row, index){
-      console.log(row);
       if (index === config.headerRow) {
         header = row;
       } else if (index >= bodyStart) {

--- a/libs/index.js
+++ b/libs/index.js
@@ -65,7 +65,7 @@ CV.prototype.cvjson = function(csv, config, callback) {
       return row;
     })
     .on('record', function(row, index){
-
+      console.log(row);
       if (index === config.headerRow) {
         header = row;
       } else if (index >= bodyStart) {
@@ -73,7 +73,7 @@ CV.prototype.cvjson = function(csv, config, callback) {
         header.forEach(function(column, index) {
           var key = config.lowerCaseHeaders ? column.trim().toLowerCase() : column.trim();
           obj[key] = row[index].trim();
-        })
+        });
         record.push(obj);
       }
     })

--- a/libs/index.js
+++ b/libs/index.js
@@ -56,7 +56,7 @@ CV.prototype.cvjson = function(csv, config, callback) {
   var header = []
 
   var headerRow = config.headerRow || 0;
-  var bodyStart = config.bodyRow || config.headerRow + 1;
+  var bodyStart = config.bodyStart || config.headerRow + 1;
 
   cvcsv()
     .from.string(csv)

--- a/libs/index.js
+++ b/libs/index.js
@@ -71,7 +71,7 @@ CV.prototype.cvjson = function(csv, config, callback) {
         var obj = {};
         header.forEach(function(column, index) {
           var key = config.lowerCaseHeaders ? column.trim().toLowerCase() : column.trim();
-          obj[key] = row[index].trim();
+          if (!obj[key]) obj[key] = row[index].trim();
         });
         record.push(obj);
       }
@@ -92,3 +92,4 @@ CV.prototype.cvjson = function(csv, config, callback) {
       console.error(error.message);
     });
 }
+


### PR DESCRIPTION
These changes allow the user to specify a 'headerRow' attribute to the config to define the row on which the header titles are located. Additionally they can use the 'bodyStart' attribute to specify what row the data begins on, in case there is a gap between the header and the body of data.